### PR TITLE
Compare matchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 spec_app/build/*
+.idea/

--- a/lib/bacon-expect.rb
+++ b/lib/bacon-expect.rb
@@ -3,7 +3,7 @@ unless defined?(Motion::Project::Config)
 end
 
 Motion::Project::App.setup do |app|
-  Dir.glob(File.join(File.dirname(__FILE__), 'bacon-expect/**/*.rb')).reverse.each do |file|
+  Dir.glob(File.join(File.dirname(__FILE__), 'bacon-expect/**/*.rb')).sort.reverse.each do |file|
     app.spec_files << file
   end
 end

--- a/lib/bacon-expect/fail_message_renderer.rb
+++ b/lib/bacon-expect/fail_message_renderer.rb
@@ -49,7 +49,11 @@ module BaconExpect
     def self.message_for_be_eq(negated, subject, value)
       "#{subject.inspect}#{expectation(negated)} to be == to #{value.inspect}"
     end
-    
+
+    def self.message_for_be_compared(negated, subject, operator, value)
+      "#{subject.inspect}#{expectation(negated)} to be #{operator} to #{value.inspect}"
+    end
+
     def self.message_for_have_generic(negated, subject, method_name, values)
       message = "#{subject.inspect} #has_#{method_name}?"
       message += "(#{values.map(&:inspect).join(', ')})" unless values.empty?

--- a/lib/bacon-expect/matchers/be_compare_to.rb
+++ b/lib/bacon-expect/matchers/be_compare_to.rb
@@ -1,0 +1,27 @@
+module BaconExpect; module Matcher
+  class BeMatcher
+    [:==, :<, :<=, :>=, :>, :===, :=~].each do |operator|
+      define_method operator do |operand|
+        BeComparedTo.new(operator, operand)
+      end
+    end
+  end
+
+  class BeComparedTo < SingleMethod
+    def matches?(actual)
+      @actual = actual
+      @actual.__send__ @method_name, *@values
+    rescue ArgumentError, NoMethodError
+      false
+    end
+
+    def fail!(subject, negated)
+      raise FailedExpectation, fail_message(subject, negated)
+    end
+
+    def fail_message(subject, negated = false)
+      FailMessageRenderer.message_for_be_compared(negated, subject, @method_name, *@values)
+    end
+  end
+end; end
+

--- a/lib/bacon-expect/matchers/matchers.rb
+++ b/lib/bacon-expect/matchers/matchers.rb
@@ -22,13 +22,16 @@ module BaconExpect
         Eql.new(value)
       end
 
-      def be(value)
+      def equal(value)
         Be.new(value)
       end
-      alias_method :equal, :be
 
       def eq(value)
         Eq.new(value)
+      end
+
+      def be(*args)
+        args.empty? ? BeMatcher.new : Be.new(*args)
       end
 
       def match(regex)

--- a/spec_app/Rakefile
+++ b/spec_app/Rakefile
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios'
 
 begin

--- a/spec_app/spec/matchers/be_compare_to_spec.rb
+++ b/spec_app/spec/matchers/be_compare_to_spec.rb
@@ -1,0 +1,9 @@
+describe "Matcher::BeCompareTo" do
+  it 'be > passes when greater' do
+    expect(1).to be > 0
+  end
+
+  it 'be > fails when lesser' do
+    expect_failure('1 expected to be < to 0') { expect(1).to be < 0 }
+  end
+end


### PR DESCRIPTION
This adds compare matchers

e.g. `expect(x).to be > 0`

operators handled `==`, `<`, `<=`, `>=`, `>`, `===`, `=~`

Inspired by rspec-expectiations 